### PR TITLE
Click to dial

### DIFF
--- a/flex-config/ui_attributes.common.json
+++ b/flex-config/ui_attributes.common.json
@@ -9,23 +9,23 @@
       "activity_skill_filter": {
         "enabled": true,
         "rules": {
-          "On a Task" : {
+          "On a Task": {
             "required_skill": "system_activities",
             "sort_order": 0
           },
-          "On a Task, No ACD" : {
+          "On a Task, No ACD": {
             "required_skill": "system_activities",
             "sort_order": 0
           },
-          "Wrap Up" : {
+          "Wrap Up": {
             "required_skill": "system_activities",
             "sort_order": 0
           },
-          "Wrap Up, No ACD" : {
+          "Wrap Up, No ACD": {
             "required_skill": "system_activities",
             "sort_order": 0
           },
-          "Offline" : {
+          "Offline": {
             "required_skill": null,
             "sort_order": 100
           }
@@ -226,10 +226,7 @@
         "per_queue": {
           "exampleQueueSid": {
             "require_disposition": true,
-            "dispositions": [
-              "Promotional Sale",
-              "Renewal"
-            ]
+            "dispositions": ["Promotional Sale", "Renewal"]
           }
         }
       },
@@ -262,6 +259,9 @@
           "location": false,
           "agent_skills": true
         }
+      },
+      "click_to_dial": {
+        "enabled": true
       }
     }
   }

--- a/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/config.ts
@@ -1,0 +1,8 @@
+import { getFeatureFlags } from '../../utils/configuration';
+import ClickToDialConfig from './types/ServiceConfiguration';
+
+const { enabled = false } = (getFeatureFlags()?.features?.click_to_dial as ClickToDialConfig) || {};
+
+export const isFeatureEnabled = () => {
+  return enabled;
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/flex-hooks/actions/StartOutboundCall.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/flex-hooks/actions/StartOutboundCall.ts
@@ -1,0 +1,31 @@
+import * as Flex from '@twilio/flex-ui';
+
+import { isFeatureEnabled } from '../../config';
+import { FlexAction, FlexActionEvent } from '../../../../types/feature-loader';
+
+export const actionName = FlexAction.StartOutboundCall;
+export const actionEvent = FlexActionEvent.after;
+export const actionHook = async function enhanceClickToDialTaskAttributes(flex: typeof Flex) {
+  if (!isFeatureEnabled()) return;
+  flex.Actions.addListener(`${actionEvent}${actionName}`, async (payload) => {
+    console.warn(`afterStartOutboundCall Listener Triggered`);
+    console.warn(payload);
+    // Adding a window Event Listener to intercept attributes that are passed via the openCTI
+    window.addEventListener('message', async (event) => {
+      if (event.data.apiType === 'opencti') {
+        console.warn('Window EventListner Triggered!');
+        console.warn(event);
+        console.warn('Response =', event.data.response);
+        const windowResponse = event.data.response.returnValue;
+        payload.taskAttributes = {
+          case_id: windowResponse.recordId,
+          phoneNumber: windowResponse.number,
+          recordId: windowResponse.recordId,
+          recordName: windowResponse.recordName,
+          objectType: windowResponse.objectType,
+          origin: 'SFDC',
+        };
+      }
+    });
+  });
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/index.ts
@@ -1,0 +1,9 @@
+import { FeatureDefinition } from '../../types/feature-loader';
+import { isFeatureEnabled } from './config';
+// @ts-ignore
+import hooks from './flex-hooks/**/*.*';
+
+export const register = (): FeatureDefinition => {
+  if (!isFeatureEnabled()) return {};
+  return { name: 'click-to-dial', hooks: typeof hooks === 'undefined' ? [] : hooks };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/click-to-dial/types/ServiceConfiguration.ts
@@ -1,0 +1,3 @@
+export default interface ClickToDialConfig {
+  enabled: boolean;
+}


### PR DESCRIPTION
### Summary

Added click to dial, specifically for Salesforce's OpenCTI integration.  This feature will allow us to intercept the window events and be able to have access to attributes passed from the Salesforce record.  Ultimately this could be used to present information to the agent in flex or more importantly pass task attributes that could be used to enhance conversation attributes for reporting

### Checklist

- [ x ] Tested changes end to end
- [ x ] Updated documentation
- [ x ] Requested one or more reviewers
